### PR TITLE
Use exceptions to terminate search (rebased)

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -183,7 +183,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
 
   for (Thread* th : Threads)
   {
-      th->nodes = th->tbHits = 0;
+      th->nodes = th->nodesTime = th->tbHits = 0;
       th->rootDepth = th->completedDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);

--- a/src/thread.h
+++ b/src/thread.h
@@ -56,6 +56,7 @@ public:
   void idle_loop();
   void start_searching();
   void wait_for_search_finished();
+  void check_break();
 
   Pawns::Table pawnsTable;
   Material::Table materialTable;
@@ -63,6 +64,7 @@ public:
   size_t PVIdx;
   int selDepth;
   std::atomic<uint64_t> nodes, tbHits;
+  uint64_t nodesTime;
 
   Position rootPos;
   Search::RootMoves rootMoves;
@@ -81,12 +83,10 @@ struct MainThread : public Thread {
   using Thread::Thread;
 
   void search() override;
-  void check_time();
 
   bool failedLow;
   double bestMoveChanges, previousTimeReduction;
   Value previousScore;
-  int callsCnt;
 };
 
 


### PR DESCRIPTION
Fixes issue #1232

passed sprt @ 10+0.1 th 1
http://tests.stockfishchess.org/tests/view/59cc891f0ebc5916ff64b86f
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 52063 W: 9192 L: 9123 D: 33748
elo =    0.460 +-    1.768 LOS:   69.5%

passed sprt @ 5+0.05 th 5
http://tests.stockfishchess.org/tests/view/59cd23540ebc5916ff64b8ae
LLR: 2.95 (-2.94,2.94) [-4.00,0.00]
Total: 74535 W: 11934 L: 12013 D: 50588
elo = -0.368 +- 1.412 LOS: 30.5%

The search loop (including ID loop, and aspiration) can now only be quit throwing an exception via break_search(). This allows for removing quite some logic in search, and reorganizing Thread::search() to be more clear and concise.

The catch block must restore the rootPos, as well as sort the rootMoves, and possibly output the new PV.

The exception based approach to quit the search is essentially instantaneous, but practically, that is only a small advantage over the old implementation. The stop signal, as well as the clock is only checked in one place, namely check_time(), which is called only from the central search() function. While the stop signal is checked on every call, by all threads, time is checked (as in master) only by the main thread. Now, time checking is every ~8000 nodes, rather than counting the calls to search(). This yields potentially a more homogeneous sampling for the time, as also longer qsearches are taken into account.

unchanged bench:  5536775